### PR TITLE
Css percentage

### DIFF
--- a/percentage.html
+++ b/percentage.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+  <!-- percentage 參考基準? -->
+  <!-- A percentage is relative to whatever the parent container's size is. -->
+  <link rel="stylesheet" href="reset.css">
+  <style>
+    .wrap{
+      width: 500px;
+      height: 500px;
+      border: deeppink 2px solid;
+      margin: 10px auto;
+    }
+    .item{
+      display: inline-block;
+      width: 30%;
+      height: 30%;
+      border: tan 1px solid;
+    }
+
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+  </div>
+
+</body>
+</html>

--- a/percentage.html
+++ b/percentage.html
@@ -19,13 +19,22 @@
       display: inline-block;
       width: 30%;
       height: 30%;
-      border: tan 1px solid;
+      background-color: #f00;
+    }
+    .nowh{
+      background-color: #0f0;
     }
 
   </style>
 </head>
 <body>
   <div class="wrap">
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+  </div>
+
+  <div class="nowh">
     <div class="item"></div>
     <div class="item"></div>
     <div class="item"></div>

--- a/percentage.html
+++ b/percentage.html
@@ -16,7 +16,7 @@
       margin: 10px auto;
     }
     .item{
-      display: inline-block;
+      /* display: inline-block; */
       width: 30%;
       height: 30%;
       background-color: #f00;


### PR DESCRIPTION
子層 percentage 參考基準?
---
- A percentage is relative to whatever the parent container’s size is.
- 子層 (.item) 參考 父層 (.wrap) 的 width, height
- 父層無實質width, height，子層的 percentage 無法參考，則子層消失
```html
<style>
    .nowh{
      background-color: #0f0;
    }
    .item{
      display: inline-block;
      width: 30%;
      height: 30%;
      border: tan 1px solid;
    }
</style>

<body>
  <div class="nowh">
    <div class="item"></div>
    <div class="item"></div>
    <div class="item"></div>
  </div>
</body>
```

## 子層顯示，表示父層：
- 父層設定 border 時，會被納入 content box，造成誤判子層未消失
- 子層 (.item) display: inline-block; ，造成父層無實質尺寸卻仍可看到背景顏色
- 子層去除 display: inline-block; ，則 父層的背景色一併消失
```html
<style>
    .nowh{
      background-color: #0f0;
    }
    .item{
      display: inline-block;
      width: 30%;
      height: 30%;
      border: tan 1px solid;
    }
</style>

<body>
  <div class="nowh">
    <div class="item"></div>
    <div class="item"></div>
    <div class="item"></div>
  </div>
</body>
```
