### PR TITLE
Css/pseudo elements

### DIFF
--- a/toyota/descript.html
+++ b/toyota/descript.html
@@ -10,17 +10,24 @@
   <link rel="stylesheet" href="../reset.css">
   <style>
     .text{
-      width: 600px;
+      width: 960px;
       background-color: #fa0;
       font-size: 36px;
       margin: 0 auto;
       text-align: center;
+      line-height: 48px;
     }
     .text::after{
       content: "<- 初";
       display: inline-block;
       color: #f00;
       background-color: #000;
+    }
+    .text::before{
+      content: "";
+      display: inline-block;
+      padding: 10px;
+      background-color: #f00;
     }
     
   </style>

--- a/toyota/descript.html
+++ b/toyota/descript.html
@@ -10,14 +10,32 @@
   <link rel="stylesheet" href="../reset.css">
   <style>
     .text{
-      width: 960px;
+      width: 600px;
       background-color: #fa0;
-      font-size: 36px;
       margin: 0 auto;
-      text-align: center;
-      line-height: 48px;
+      padding: 10px;
+      line-height: 30px;
     }
-    .text::after{
+    .text h2{
+      display: inline-block;
+      padding: 2px;
+      font-size: 24px;
+      background-color: #fff;
+    }
+    .text p{
+      font-size: 18px;
+      text-indent: 1em;
+      position: relative;
+    }
+    .text p::before{
+      display: inline-block;
+      content: "X";
+      padding-right: 5px;
+      position: absolute;
+      left: -15px;
+    }
+    /* 偽選取器-基本操作 */
+    /* .text::after{
       content: "<- 初";
       display: inline-block;
       color: #f00;
@@ -28,13 +46,18 @@
       display: inline-block;
       padding: 10px;
       background-color: #f00;
-    }
+    } */
     
   </style>
 </head>
 <body>
   <div class="text">
-    Here is some generic content
+    <h2>蘇珊大嬸</h2>
+    <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
+    <h2>湯姆大叔</h2>
+    <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
+    <h2>捷克</h2>
+    <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
   </div>
 </body>
 </html>

--- a/toyota/descript.html
+++ b/toyota/descript.html
@@ -39,16 +39,19 @@
     }
     .text .singer p{
       font-size: 18px;
-      text-indent: 1em;
+      padding-left: 1.5em;
       position: relative;
     }
     /* 偽選取器-項目符號-調整位置 */
     .text p::before{
-      display: inline-block;
-      content: "X";
-      padding-right: 5px;
+      content: "";
+      width: 8px;
+      height: 8px;
+      background-color: #a00;
       position: absolute;
-      left: -15px;
+      left: 10px;
+      top: 0.5em;
+      border-radius: 50%;
     }
     /* 偽選取器-基本操作 */
     /* .text::after{

--- a/toyota/descript.html
+++ b/toyota/descript.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+  <!-- Pseudo-elements, css cosmetic content  -->
+  <!-- css 偽元素：  ::before and ::after -->
+  <link rel="stylesheet" href="../reset.css">
+  <style>
+    .text{
+      width: 600px;
+      background-color: #fa0;
+      font-size: 36px;
+      margin: 0 auto;
+      text-align: center;
+    }
+    .text::after{
+      content: "<- 初";
+      display: inline-block;
+      color: #f00;
+      background-color: #000;
+    }
+    
+  </style>
+</head>
+<body>
+  <div class="text">
+    Here is some generic content
+  </div>
+</body>
+</html>

--- a/toyota/descript.html
+++ b/toyota/descript.html
@@ -15,6 +15,9 @@
       margin: 0 auto;
       padding: 10px;
       line-height: 30px;
+      /*  */
+      display: flex;
+      flex-wrap: wrap;
     }
     .slg{
       color: brown;
@@ -22,6 +25,10 @@
       padding: 10px;
       display: flex;
       align-items: center;
+      /* 列轉欄，slg 要將內文擠下去，使用width: 100% */
+      width: 100%;
+      flex-grow: 1;
+
     }
     .slg::after{
       content: "";
@@ -33,6 +40,8 @@
     }
     .text .singer{
       margin-bottom: 20px;
+
+      width: 200px;
     }
     .text .singer h2{
       display: inline-block;

--- a/toyota/descript.html
+++ b/toyota/descript.html
@@ -31,6 +31,9 @@
       margin-bottom: auto; */
       margin-left: 20px;
     }
+    .text .singer{
+      margin-bottom: 20px;
+    }
     .text .singer h2{
       display: inline-block;
       padding: 2px;
@@ -75,8 +78,16 @@
     <div class="singer">
       <h2>蘇珊大嬸</h2>
       <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
+      <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
+      <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
+    </div>
+
+    <div class="singer">
       <h2>湯姆大叔</h2>
       <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
+    </div>
+    
+    <div class="singer">
       <h2>捷克</h2>
       <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
     </div>

--- a/toyota/descript.html
+++ b/toyota/descript.html
@@ -21,13 +21,14 @@
       font-size: 24px;
       padding: 10px;
       display: flex;
+      align-items: center;
     }
     .slg::after{
       content: "";
       flex-grow: 1;
       border-bottom: brown 1px solid;
-      margin-top: auto;
-      margin-bottom: auto;
+      /* margin-top: auto;
+      margin-bottom: auto; */
       margin-left: 20px;
     }
     .text .singer h2{

--- a/toyota/descript.html
+++ b/toyota/descript.html
@@ -16,17 +16,32 @@
       padding: 10px;
       line-height: 30px;
     }
-    .text h2{
+    .slg{
+      color: brown;
+      font-size: 24px;
+      padding: 10px;
+      display: flex;
+    }
+    .slg::after{
+      content: "";
+      flex-grow: 1;
+      border-bottom: brown 1px solid;
+      margin-top: auto;
+      margin-bottom: auto;
+      margin-left: 20px;
+    }
+    .text .singer h2{
       display: inline-block;
       padding: 2px;
       font-size: 24px;
       background-color: #fff;
     }
-    .text p{
+    .text .singer p{
       font-size: 18px;
       text-indent: 1em;
       position: relative;
     }
+    /* 偽選取器-項目符號-調整位置 */
     .text p::before{
       display: inline-block;
       content: "X";
@@ -52,12 +67,15 @@
 </head>
 <body>
   <div class="text">
-    <h2>蘇珊大嬸</h2>
-    <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
-    <h2>湯姆大叔</h2>
-    <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
-    <h2>捷克</h2>
-    <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
+    <div class="slg">超級偶像杯</div>
+    <div class="singer">
+      <h2>蘇珊大嬸</h2>
+      <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
+      <h2>湯姆大叔</h2>
+      <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
+      <h2>捷克</h2>
+      <p>維修細胞觀點在這個小時大戰，西安見過成本等待興趣臺灣民眾網際高興是怎麼便是，考。</p>
+    </div>
   </div>
 </body>
 </html>

--- a/toyota/margin_auto.html
+++ b/toyota/margin_auto.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>margin: auto</title>
+  <link rel="stylesheet" href="../reset.css">
+  <!-- 為什麼 div 物件用內容撐開的 width 使用 margin: auto; 時，無法置中， 需要將 div 物件設定 width，才能使用 margin: auto; 達成置中？ -->
+  <style>
+    .text{
+      /* width: 600px; */
+      background-color: #fa0;
+      border: springgreen 2px dashed;
+      font-size: 36px;
+      /* margin: 0 auto; */
+    }
+  </style>
+</head>
+<body>
+  <div class="text">
+    Here is some generic content
+  </div>
+</body>
+</html>

--- a/toyota/margin_auto.html
+++ b/toyota/margin_auto.html
@@ -7,13 +7,14 @@
   <title>margin: auto</title>
   <link rel="stylesheet" href="../reset.css">
   <!-- 為什麼 div 物件用內容撐開的 width 使用 margin: auto; 時，無法置中， 需要將 div 物件設定 width，才能使用 margin: auto; 達成置中？ -->
+  <!-- 設定 div 的 width 後，才能使 margin: auto 控制 div 的左右空間 -->
   <style>
     .text{
-      /* width: 600px; */
       background-color: #fa0;
       border: springgreen 2px dashed;
       font-size: 36px;
-      /* margin: 0 auto; */
+      width: 600px;
+      margin: 0 auto;
     }
   </style>
 </head>


### PR DESCRIPTION
偽選取器 ::before and ::after
===

起手式：
- ::before or ::after
- content: ""; or content: ''; or content: "whatever";
- inline by default

偽選取器-項目符號
- display: inline-block;
- 依 block 特性，改變 content 外型，製作項目符號

偽選取器-line-垂直居中
- flex + align-items
- flex + margin

偽選取器-項目符號-位置
- 符號使用 position: absolute;
- padding-left 空出空間，製造整個段落縮排的效果，再使用 absolute 調整**項目符號**位置
---
設想資料可能增加、格式變化，在本例使用 多個 singer 包住內文，增加切版靈活度。多一層 singer，singer 在 flex 列轉欄時，易操控 css 格式；singer 在 flex 時 ，要將 slg 的寬度提升至折行的寬度，使用 width: 100%，將其他內文擠下去。